### PR TITLE
Migrate to JSON::MaybeXS

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,7 +1,7 @@
 requires 'Moose';
 requires 'MooseX::StrictConstructor';
 requires 'MooseX::SlurpyConstructor';
-requires 'JSON';
+requires 'JSON::MaybeXS';
 requires 'Module::Runtime';
 
 on test => sub {

--- a/lib/Cfn.pm
+++ b/lib/Cfn.pm
@@ -487,7 +487,7 @@ package Cfn::Value::Primitive {
 
 package Cfn::Boolean {
   use Moose;
-  use JSON;
+  use JSON::MaybeXS;
   extends 'Cfn::Value::Primitive';
   has '+Value' => (isa => 'Bool');
   has stringy => (is => 'ro', required => 1, isa => 'Bool');
@@ -973,8 +973,8 @@ package Cfn {
   }
 
   has json => (is => 'ro', lazy => 1, default => sub {
-      require JSON;
-      return JSON->new->canonical
+      require JSON::MaybeXS;
+      return JSON::MaybeXS->new->canonical
     });
 
   sub as_json {
@@ -986,8 +986,8 @@ package Cfn {
   sub from_json {
     my ($class, $json) = @_;
 
-    require JSON;
-    return $class->from_hashref(JSON::from_json($json));
+    require JSON::MaybeXS;
+    return $class->from_hashref(JSON::MaybeXS::from_json($json));
   }
 }
 

--- a/t/012_duplicate_keys.t
+++ b/t/012_duplicate_keys.t
@@ -1,3 +1,10 @@
+#!/usr/bin/env perl
+
+use Cfn;
+use Test::More;
+use Test::Exception;
+
+my $content = <<EOF;
 {
   "AWSTemplateFormatVersion" : "2010-09-09",
 
@@ -27,3 +34,9 @@
   "Outputs" : {
   }
 }
+EOF
+
+throws_ok(sub { Cfn->from_json($content) }, qr/Duplicate keys not allowed/);
+
+done_testing;
+


### PR DESCRIPTION
Since it's a stricter parser, duplicate keys aren't allowed (which is good)
Now we have a test for this condition too